### PR TITLE
updated module name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Because the usages and results of the two implementations differ, and it's nice 
 
 ```javascript
 //promises!
-const enumerateDevices = require('enumerateDevices');
+const enumerateDevices = require('enumerate-devices');
 
 enumerateDevices().then((devices) => console.log(devices)).catch(console.log.bind(console));
 
 //or callbacks!
 
-var enumerateDevices = require('enumerateDevices');
+var enumerateDevices = require('enumerate-devices');
 
 enumerateDevices(function(err, devices) {
     if(err) {


### PR DESCRIPTION
changed from `require('enumerateDevices')` to `require('enumerate-devices')` following the name change from commit 84c21ad

I guess you could even rename this repo `enumerate-devices` for consistency.
Thanks for this little handy tool :)
