### PR TITLE
Rejecting METHOD_NOT_AVAILABLE error as an Error object

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,8 @@ module.exports = function (cb) {
         } else if (window.MediaStreamTrack && window.MediaStreamTrack.getSources) {
             window.MediaStreamTrack.getSources(processDevices);
         } else {
-            var err = {
-                message: 'Device enumeration not supported.',
-                kind: 'METHOD_NOT_AVAILABLE'
-            };
+            var err = new Error('Device enumeration not supported.');
+            err.kind = 'METHOD_NOT_AVAILABLE';
             reject(err);
             if (cb) {
                 console.warn('module now uses promise based api - callback is deprecated');


### PR DESCRIPTION
 instead of a simple object.
Gives access to Error attributes that might be expected by error catchers in project integrating this lib,
especially the stack trace
